### PR TITLE
feat: add optional offline username coloring

### DIFF
--- a/src/main/java/com/offlineChatIcon/OfflineChatIconConfig.java
+++ b/src/main/java/com/offlineChatIcon/OfflineChatIconConfig.java
@@ -1,0 +1,42 @@
+package com.offlineChatIcon;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.*;
+
+@ConfigGroup("offlineChatIcon")
+public interface OfflineChatIconConfig extends Config
+{
+
+    @ConfigItem(
+            keyName = "enableOfflineIcon",
+            name = "Show offline icon",
+            description = "Display an icon next to offline clan members' names",
+            position = 0
+    )
+    default boolean enableOfflineIcon() { return true; }
+
+    @ConfigItem(
+            keyName = "enableOfflineColor",
+            name = "Enable offline color",
+            description = "Change the color of offline clan members' names",
+            position = 1
+    )
+    default boolean enableOfflineColor()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "offlineColor",
+            name = "Offline color",
+            description = "Choose the color for offline clan members' names",
+            position = 2
+    )
+    default Color offlineColor()
+    {
+        return Color.DARK_GRAY;
+    }
+}


### PR DESCRIPTION
Added optional offline username coloring. The icon feature remains and now works alongside optional color highlighting.
Both features are toggleable in the config panel. This gives users an option if they don't want to have another icon in their chat (alongside clanrank, ironman, pmod etc.). If you decide to implement this the plugin name and readme should probably be changed, but I feel like that is not up to me. 

<sup>I am new to Git(Hub) so I probably did something wrong lol.</sup>